### PR TITLE
Fix timer not incrementing correctly due to interval logic

### DIFF
--- a/app/Timer.tsx
+++ b/app/Timer.tsx
@@ -4,7 +4,7 @@ import { View, Text, Button, StyleSheet } from 'react-native';
 const Timer: React.FC = () => {
   const [seconds, setSeconds] = useState(0);
   const [isRunning, setIsRunning] = useState(false);
-  const intervalRef = useRef<NodeJS.Timeout | null>(null); // 使用 useRef 来保存 interval
+  const intervalRef = useRef<NodeJS.Timeout | null>(null); 
 
   useEffect(() => {
     if (isRunning && intervalRef.current === null) {
@@ -19,7 +19,6 @@ const Timer: React.FC = () => {
     }
 
     return () => {
-      // 组件卸载时清除 interval
       if (intervalRef.current !== null) {
         clearInterval(intervalRef.current);
         intervalRef.current = null;

--- a/app/Timer.tsx
+++ b/app/Timer.tsx
@@ -1,39 +1,40 @@
-// Timer.tsx
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { View, Text, Button, StyleSheet } from 'react-native';
 
 const Timer: React.FC = () => {
   const [seconds, setSeconds] = useState(0);
   const [isRunning, setIsRunning] = useState(false);
-  const [intervalId, setIntervalId] = useState<NodeJS.Timeout | null>(null); // Track the interval ID
+  const intervalRef = useRef<NodeJS.Timeout | null>(null); // 使用 useRef 来保存 interval
 
   useEffect(() => {
-    // If the timer is running, set the interval
-    if (isRunning) {
-      const interval = setInterval(() => {
+    if (isRunning && intervalRef.current === null) {
+      intervalRef.current = setInterval(() => {
         setSeconds(prev => prev + 1);
       }, 1000);
-      setIntervalId(interval); // Save the interval ID
-    } else {
-      if (intervalId) {
-        clearInterval(intervalId); // Clear the interval when stopping the timer
-      }
+    }
+
+    if (!isRunning && intervalRef.current !== null) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
     }
 
     return () => {
-      if (intervalId) {
-        clearInterval(intervalId); // Cleanup on component unmount
+      // 组件卸载时清除 interval
+      if (intervalRef.current !== null) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
       }
     };
-  }, [isRunning, intervalId]); // Use `intervalId` as dependency
+  }, [isRunning]);
 
   const handleStartStop = () => {
-    setIsRunning(prev => !prev); // Toggle the timer state
+    setIsRunning(prev => !prev);
   };
 
   const handleReset = () => {
-    if (intervalId) {
-      clearInterval(intervalId); // Clear the interval when resetting
+    if (intervalRef.current !== null) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
     }
     setSeconds(0);
     setIsRunning(false);


### PR DESCRIPTION
### What I fixed
- Replaced useState-based interval tracking with useRef to avoid unintended re-renders
- Ensured setInterval starts only when timer is running
- Cleared interval properly on stop, reset, and component unmount

### Why
Using useState to track the interval ID caused unnecessary re-renders and multiple intervals being set/cleared. This fix ensures the timer works smoothly and only updates once per second while running.

